### PR TITLE
Update URL to bukkit Maven Repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
 
 	<repositories>
 		<!-- specify where to find bukkit artifacts -->
-		<repository>
-			<id>bukkut-repo</id>
-			<url>http://artifacts.lukegb.com/artifactory/repo</url>
-		</repository>
+    <repository>
+      <id>repobo-snap</id>
+      <url>http://repo.bukkit.org/content/groups/public</url>
+    </repository>
 		<!-- specify where to find groovy artifacts -->
 		<repository>
 			<id>codehaus.org</id>


### PR DESCRIPTION
I was trying to build with Maven and got this error:

[ERROR] Failed to execute goal on project GroovyBukkit: Could not resolve dependencies for project org.bukkit.plugin:GroovyBukkit:jar:0.8-SNAPSHOT: Failed to collect dependencies for [org.bukkit:bukkit:jar:1.2.4-R1.1-SNAPSHOT (compile), org.bukkit:craftbukkit:jar:1.2.4-R1.1-SNAPSHOT (compile), org.codehaus.groovy:groovy:jar:1.8.6 (compile), junit:junit:jar:4.10 (test)]: Failed to read artifact descriptor for org.bukkit:bukkit:jar:1.2.4-R1.1-SNAPSHOT: Could not transfer artifact org.bukkit:bukkit:pom:1.2.4-R1.1-SNAPSHOT from/to bukkut-repo (http://artifacts.lukegb.com/artifactory/repo): artifacts.lukegb.com: Unknown host artifacts.lukegb.com -> [Help 1]

Changing the repo URL fixed it.
